### PR TITLE
fix: download icons creates a new connection per download

### DIFF
--- a/download_icons.py
+++ b/download_icons.py
@@ -13,6 +13,8 @@ for line in installer.split("\n"):
 
 resfile = requests.get(f"https://binaries.eveonline.com/{resfileindex}").text
 
+session = requests.Session()
+
 for line in resfile.split("\n"):
     if not line:
         continue
@@ -26,4 +28,4 @@ for line in resfile.split("\n"):
 
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
         with open(local_path, "wb") as f:
-            f.write(requests.get(f"https://resources.eveonline.com/{path}").content)
+            f.write(session.get(f"https://resources.eveonline.com/{path}").content)


### PR DESCRIPTION
Instead, use a single connection for all downloads; this doesn't only improve download speed, it also avoids wasting resources on both ends.