### PR TITLE
chore(ci): embed the SDE version as minor version (instead of pre-release version)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Validate SDE version
       run: |
         SDE_VERSION=$(date -r sde.zip "+%F" | sed 's/-//g')
-        RELEASE_SDE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d- -f2)
+        RELEASE_SDE_VERSION=$(echo ${{ github.ref_name }} | cut -d. -f3)
 
         echo "SDK version: ${SDE_VERSION}"
         echo "Release version: ${RELEASE_SDE_VERSION}"
@@ -89,7 +89,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         registry: "https://npm.pkg.github.com"
         package: package.json
-  
+
     - name: Publish to R2 bucket
       run: |
         rclone copy dist eveshipfit:eveshipfit/${{ github.event.release.tag_name }}/ --progress --exclude=*.{js,js.map,d.ts}


### PR DESCRIPTION
This helps out with npm to understand what "^9" means, as that normally skips pre-release versions.