### PR TITLE
fix: lower alignTime is good, not bad

### DIFF
--- a/patches/alignTime.yaml
+++ b/patches/alignTime.yaml
@@ -7,7 +7,7 @@ attributes:
   published: true
   # -ln(0.25) == 1.3862943611198906
   defaultValue: 1.3862943611198906
-  highIsGood: true
+  highIsGood: false
   stackable: true
 
 effects:


### PR DESCRIPTION
As noted by https://github.com/EVEShipFit/react/pull/157, align-time should have `highIsGood` set to false: lower numbers are better.